### PR TITLE
Fix field metadata on edit.

### DIFF
--- a/src/thompsonaccounting/index.ts
+++ b/src/thompsonaccounting/index.ts
@@ -870,6 +870,21 @@ export const updateField = async (req: Request, res: Response, next: any) => {
       next();
       return;
     }
+
+    query = {
+      name: "UpdateFieldMetadataName",
+      text: "UPDATE field_metadata SET field_name = $1 WHERE field_name=$2 RETURNING *;",
+      values: [newFieldName, fieldName],
+    };
+    ({ code, rows } = await performQuery(client, query));
+    if (code !== 200 || rows.length === 0) {
+      res.status(400);
+      res.write(
+        JSON.stringify({ message: "Couldn't update field metadata name." })
+      );
+      next();
+      return;
+    }
   }
 
   // update the required status of the column.


### PR DESCRIPTION
When updating a tab name, the field metadata column would no longer match up with the actual field name, as the tab name is used to compute the salt added to field names to make them unique.